### PR TITLE
Add trait for iter_hosts and iter_targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,9 @@ pub mod prelude {
             AeryQueryExt, ControlFlow, FoldBreadth, ForEachPermutations, ForEachPermutations3Arity,
             Join, Relations, Traverse,
         },
-        relation::{CheckRelations, CleanupPolicy, Participates, Relation, Root, ZstOrPanic},
+        relation::{
+            CheckRelations, CleanupPolicy, IterRelations, Participates, Relation, Root, ZstOrPanic,
+        },
         scope::Scope,
         tuple_traits::{Joinable, RelationSet},
         Aery,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -85,7 +85,7 @@ impl<R: RelationSet> CheckRelations for Option<&RelationsItem<'_, R>> {
         relation: impl Into<crate::Var<crate::relation::RelationId>>,
         host: impl Into<crate::Var<Entity>>,
     ) -> bool {
-        self.is_some_and(|item| item.edges.edges.has_host(relation, host))
+        self.is_some_and(|item| item.has_host(relation, host))
     }
 
     fn has_target(
@@ -93,47 +93,37 @@ impl<R: RelationSet> CheckRelations for Option<&RelationsItem<'_, R>> {
         relation: impl Into<crate::Var<crate::relation::RelationId>>,
         target: impl Into<crate::Var<Entity>>,
     ) -> bool {
-        self.is_some_and(|item: &RelationsItem<'_, R>| {
-            item.edges.edges.has_target(relation, target)
-        })
+        self.is_some_and(|item: &RelationsItem<'_, R>| item.has_target(relation, target))
     }
 }
 
 impl<RS: RelationSet> IterRelations for RelationsItem<'_, RS> {
-    type Hosts<'a> = EdgeIter<'a>
+    type Entities<'a> = EdgeIter<'a>
     where
         Self: 'a;
 
-    type Targets<'a> = EdgeIter<'a>
-    where
-        Self: 'a;
-
-    fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_> {
+    fn iter_hosts<R: Relation>(&self) -> Self::Entities<'_> {
         self.edges.edges.iter_hosts::<R>()
     }
 
-    fn iter_targets<R: Relation>(&self) -> Self::Targets<'_> {
+    fn iter_targets<R: Relation>(&self) -> Self::Entities<'_> {
         self.edges.edges.iter_targets::<R>()
     }
 }
 
 impl<RS: RelationSet> IterRelations for Option<&RelationsItem<'_, RS>> {
-    type Hosts<'a> = std::iter::Flatten<std::option::IntoIter<EdgeIter<'a>>>
+    type Entities<'a> = std::iter::Flatten<std::option::IntoIter<EdgeIter<'a>>>
     where
         Self: 'a;
 
-    type Targets<'a> = std::iter::Flatten<std::option::IntoIter<EdgeIter<'a>>>
-    where
-        Self: 'a;
-
-    fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_> {
-        self.map(|relations| relations.edges.edges.iter_hosts::<R>())
+    fn iter_hosts<R: Relation>(&self) -> Self::Entities<'_> {
+        self.map(|relations| relations.iter_hosts::<R>())
             .into_iter()
             .flatten()
     }
 
-    fn iter_targets<R: Relation>(&self) -> Self::Targets<'_> {
-        self.map(|relations| relations.edges.edges.iter_targets::<R>())
+    fn iter_targets<R: Relation>(&self) -> Self::Entities<'_> {
+        self.map(|relations| relations.iter_targets::<R>())
             .into_iter()
             .flatten()
     }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,5 +1,5 @@
 use crate::{
-    relation::{CheckRelations, EdgeWQ, EdgeWQItem, Relation, ZstOrPanic},
+    relation::{CheckRelations, EdgeIter, EdgeWQ, EdgeWQItem, IterRelations, Relation, ZstOrPanic},
     tuple_traits::*,
 };
 use bevy::ecs::{
@@ -8,10 +8,6 @@ use bevy::ecs::{
     system::Query,
 };
 use std::{borrow::Borrow, collections::VecDeque, marker::PhantomData};
-
-type EdgeIter<'a> = std::iter::Flatten<
-    std::option::IntoIter<std::iter::Copied<indexmap::set::Iter<'a, bevy::prelude::Entity>>>,
->;
 
 /// Struct to track inner product iteration.
 pub struct EdgeProduct<'a, const N: usize> {
@@ -65,18 +61,6 @@ pub struct Relations<R: RelationSet> {
     _phantom: PhantomData<R>,
 }
 
-impl<RS: RelationSet> RelationsItem<'_, RS> {
-    pub fn iter_hosts<R: Relation>(&self) -> EdgeIter<'_> {
-        let _ = R::ZST_OR_PANIC;
-        self.edges.edges.iter_hosts::<R>()
-    }
-
-    pub fn iter_targets<R: Relation>(&self) -> EdgeIter<'_> {
-        let _ = R::ZST_OR_PANIC;
-        self.edges.edges.iter_targets::<R>()
-    }
-}
-
 impl<R: RelationSet> CheckRelations for RelationsItem<'_, R> {
     fn has_host(
         &self,
@@ -92,6 +76,66 @@ impl<R: RelationSet> CheckRelations for RelationsItem<'_, R> {
         target: impl Into<crate::Var<Entity>>,
     ) -> bool {
         self.edges.edges.has_target(relation, target)
+    }
+}
+
+impl<R: RelationSet> CheckRelations for Option<&RelationsItem<'_, R>> {
+    fn has_host(
+        &self,
+        relation: impl Into<crate::Var<crate::relation::RelationId>>,
+        host: impl Into<crate::Var<Entity>>,
+    ) -> bool {
+        self.is_some_and(|item| item.edges.edges.has_host(relation, host))
+    }
+
+    fn has_target(
+        &self,
+        relation: impl Into<crate::Var<crate::relation::RelationId>>,
+        target: impl Into<crate::Var<Entity>>,
+    ) -> bool {
+        self.is_some_and(|item: &RelationsItem<'_, R>| {
+            item.edges.edges.has_target(relation, target)
+        })
+    }
+}
+
+impl<RS: RelationSet> IterRelations for RelationsItem<'_, RS> {
+    type Hosts<'a> = EdgeIter<'a>
+    where
+        Self: 'a;
+
+    type Targets<'a> = EdgeIter<'a>
+    where
+        Self: 'a;
+
+    fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_> {
+        self.edges.edges.iter_hosts::<R>()
+    }
+
+    fn iter_targets<R: Relation>(&self) -> Self::Targets<'_> {
+        self.edges.edges.iter_targets::<R>()
+    }
+}
+
+impl<RS: RelationSet> IterRelations for Option<&RelationsItem<'_, RS>> {
+    type Hosts<'a> = std::iter::Flatten<std::option::IntoIter<EdgeIter<'a>>>
+    where
+        Self: 'a;
+
+    type Targets<'a> = std::iter::Flatten<std::option::IntoIter<EdgeIter<'a>>>
+    where
+        Self: 'a;
+
+    fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_> {
+        self.map(|relations| relations.edges.edges.iter_hosts::<R>())
+            .into_iter()
+            .flatten()
+    }
+
+    fn iter_targets<R: Relation>(&self) -> Self::Targets<'_> {
+        self.map(|relations| relations.edges.edges.iter_targets::<R>())
+            .into_iter()
+            .flatten()
     }
 }
 

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -412,7 +412,7 @@ impl IterRelations for Edges {
     fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_> {
         self.hosts[R::CLEANUP_POLICY as usize]
             .get(&RelationId::of::<R>())
-            .map(|targets| targets.iter().copied())
+            .map(|hosts| hosts.iter().copied())
             .into_iter()
             .flatten()
     }

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -185,28 +185,6 @@ pub(crate) struct Edges {
     pub targets: [HashMap<RelationId, IndexSet<Entity>>; 4],
 }
 
-type EdgeIter<'a> = std::iter::Flatten<
-    std::option::IntoIter<std::iter::Copied<indexmap::set::Iter<'a, bevy::prelude::Entity>>>,
->;
-
-impl Edges {
-    pub(crate) fn iter_hosts<R: Relation>(&self) -> EdgeIter<'_> {
-        self.hosts[R::CLEANUP_POLICY as usize]
-            .get(&RelationId::of::<R>())
-            .map(|targets| targets.iter().copied())
-            .into_iter()
-            .flatten()
-    }
-
-    pub(crate) fn iter_targets<R: Relation>(&self) -> EdgeIter<'_> {
-        self.targets[R::CLEANUP_POLICY as usize]
-            .get(&RelationId::of::<R>())
-            .map(|targets| targets.iter().copied())
-            .into_iter()
-            .flatten()
-    }
-}
-
 #[derive(WorldQuery)]
 pub struct EdgeWQ {
     pub(crate) edges: &'static Edges,
@@ -368,5 +346,148 @@ impl CheckRelations for EntityMut<'_> {
     ) -> bool {
         self.get::<Edges>()
             .map_or(false, |edges| edges.has_target(relation, target))
+    }
+}
+
+/// Trait to iterate all hosts or targets of an entity's given [`Relation`].
+pub trait IterRelations {
+    /// The iterator type returned by `iter_hosts`.
+    type Hosts<'a>: Iterator<Item = Entity>
+    where
+        Self: 'a;
+
+    /// The iterator type returned by `iter_targets`
+    type Targets<'a>: Iterator<Item = Entity>
+    where
+        Self: 'a;
+
+    /// Return all entities that target this entity with the given [`Relation`] `R`.
+    /// ```
+    ///# use bevy::prelude::*;
+    ///# use aery::{prelude::*, relation::EdgeWQItem};
+    ///#
+    ///# #[derive(Relation)]
+    ///# struct R;
+    ///#
+    ///# fn foo(entity: EdgeWQItem<'_>, e: Entity) {
+    /// for host in entity.iter_hosts::<R>() {
+    ///     // You could use the entity in a `query.get`, for example.
+    ///     // It's like a generic version of bevy's `&Parent` query param.
+    /// }
+    ///# }
+    /// ```
+    fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_>;
+
+    /// Return all entities that this entity targets with the given [`Relation`] `R`.
+    /// ```
+    ///# use bevy::prelude::*;
+    ///# use aery::{prelude::*, relation::EdgeWQItem};
+    ///#
+    ///# #[derive(Relation)]
+    ///# struct R;
+    ///#
+    ///# fn foo(entity: EdgeWQItem<'_>, e: Entity) {
+    /// for target in entity.iter_targets::<R>() {
+    ///     // You could use the entity in a `query.get`, for example.
+    ///     // It's like a generic version of bevy's `&Children` query param.
+    /// }
+    ///# }
+    /// ```
+    fn iter_targets<R: Relation>(&self) -> Self::Targets<'_>;
+}
+
+pub(crate) type EdgeIter<'a> = std::iter::Flatten<
+    std::option::IntoIter<std::iter::Copied<indexmap::set::Iter<'a, bevy::prelude::Entity>>>,
+>;
+
+impl IterRelations for Edges {
+    type Hosts<'a> = EdgeIter<'a>
+    where
+        Self: 'a;
+
+    type Targets<'a> = EdgeIter<'a>
+    where
+        Self: 'a;
+
+    fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_> {
+        self.hosts[R::CLEANUP_POLICY as usize]
+            .get(&RelationId::of::<R>())
+            .map(|targets| targets.iter().copied())
+            .into_iter()
+            .flatten()
+    }
+
+    fn iter_targets<R: Relation>(&self) -> Self::Targets<'_> {
+        self.targets[R::CLEANUP_POLICY as usize]
+            .get(&RelationId::of::<R>())
+            .map(|targets| targets.iter().copied())
+            .into_iter()
+            .flatten()
+    }
+}
+
+impl IterRelations for EdgeWQItem<'_> {
+    type Hosts<'a> = EdgeIter<'a>
+    where
+        Self: 'a;
+
+    type Targets<'a> = EdgeIter<'a>
+    where
+        Self: 'a;
+
+    fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_> {
+        self.edges.iter_hosts::<R>()
+    }
+
+    fn iter_targets<R: Relation>(&self) -> Self::Targets<'_> {
+        self.edges.iter_targets::<R>()
+    }
+}
+
+impl IterRelations for EntityRef<'_> {
+    type Hosts<'a> = std::iter::Flatten<std::option::IntoIter<EdgeIter<'a>>>
+    where
+        Self: 'a;
+
+    type Targets<'a> = std::iter::Flatten<std::option::IntoIter<EdgeIter<'a>>>
+    where
+        Self: 'a;
+
+    fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_> {
+        self.get::<Edges>()
+            .map(|edges| edges.iter_hosts::<R>())
+            .into_iter()
+            .flatten()
+    }
+
+    fn iter_targets<R: Relation>(&self) -> Self::Targets<'_> {
+        self.get::<Edges>()
+            .map(|edges| edges.iter_targets::<R>())
+            .into_iter()
+            .flatten()
+    }
+}
+
+impl IterRelations for EntityMut<'_> {
+    type Hosts<'a> = std::iter::Flatten<std::option::IntoIter<EdgeIter<'a>>>
+    where
+        Self: 'a;
+
+    type Targets<'a> = std::iter::Flatten<std::option::IntoIter<EdgeIter<'a>>>
+    where
+        Self: 'a;
+
+    fn iter_hosts<R: Relation>(&self) -> Self::Hosts<'_> {
+        self.get::<Edges>()
+            .map(|edges| edges.iter_hosts::<R>())
+            .into_iter()
+            .flatten()
+    }
+
+    fn iter_targets<R: Relation>(&self) -> Self::Targets<'_> {
+        self.get::<Edges>()
+            .map(|edges| edges.iter_targets::<R>())
+            .into_iter()
+            .flatten()
     }
 }

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -356,7 +356,7 @@ pub trait IterRelations {
     where
         Self: 'a;
 
-    /// The iterator type returned by `iter_targets`
+    /// The iterator type returned by `iter_targets`.
     type Targets<'a>: Iterator<Item = Entity>
     where
         Self: 'a;

--- a/src/tuple_traits.rs
+++ b/src/tuple_traits.rs
@@ -73,7 +73,7 @@ macro_rules! impl_product {
     ($($P:ident),*) => {
         impl<$($P: Relation),*> Product<{ count!($($P )*) }> for ($($P,)*) {
             fn product(edges: EdgeWQItem<'_>) -> EdgeProduct<'_, { count!($($P )*) }> {
-                let base_iterators = [$(edges.edges.iter_targets::<$P>(),)*];
+                let base_iterators = [$(crate::relation::IterRelations::iter_targets::<$P>(edges.edges),)*];
                 let live_iterators = base_iterators.clone();
                 let entities = [None::<Entity>; count!($($P )*)];
 


### PR DESCRIPTION
This replaces all the separate `iter_hosts` and `iter_targets` methods with a single unified trait, as well as implements it on all the same types as `CheckRelations` has implementations for.

Also fixes #13