### PR TITLE
Upgrades bevy and fixes build errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aery"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["iiYese iiyese@outlook.com"]
 repository = "https://github.com/iiYese/aery"
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11"
+bevy = "0.12"
 smallvec = "1.11.0"
 aery_macros = { path = "macros", version = "0.3.0-dev" }
 aquamarine = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ fn tick_devices(
 ### Version table
 | Bevy version | Aery verison |
 |--------------|--------------|
+| 0.12         | 0.5          |
 | 0.11         | 0.4          |
 | 0.11         | 0.3          |
 | 0.10         | 0.1 - 0.2    |

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -9,11 +9,11 @@ use bevy::{
         entity::Entity,
         query::{Or, With, Without, WorldQuery},
         system::{Command, CommandQueue, Resource},
-        world::{EntityMut, World},
+        world::World,
     },
     //hierarchy::{Children, Parent},
     log::warn,
-    prelude::{Deref, DerefMut},
+    prelude::{Deref, DerefMut, EntityWorldMut},
 };
 
 use smallvec::SmallVec;
@@ -662,7 +662,7 @@ pub trait RelationCommands {
 
 #[rustfmt::skip]
 #[allow(clippy::let_unit_value)]
-impl RelationCommands for EntityMut<'_> {
+impl RelationCommands for EntityWorldMut<'_> {
     fn set<R: Relation>(&mut self, target: Entity) -> &mut Self {
         let _ = R::ZST_OR_PANIC;
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -8,11 +8,9 @@ use crate::{
     },
 };
 
-use bevy::ecs::{
-    bundle::Bundle,
-    entity::Entity,
-    system::Command,
-    world::{EntityMut, World},
+use bevy::{
+    ecs::{bundle::Bundle, entity::Entity, system::Command, world::World},
+    prelude::EntityWorldMut,
 };
 
 use std::marker::PhantomData;
@@ -45,7 +43,7 @@ impl<R: Relation> Scope<'_, R> {
 
     /// Spawn an entity and have it target the currently scoped entity via.
     /// This function takes a closure to provide entity mut access.
-    pub fn add_and(&mut self, mut func: impl for<'e> FnMut(&mut EntityMut<'e>)) -> &mut Self {
+    pub fn add_and(&mut self, mut func: impl for<'e> FnMut(&mut EntityWorldMut<'e>)) -> &mut Self {
         let id = {
             let mut spawned = self.world.spawn(());
             func(&mut spawned);
@@ -61,7 +59,7 @@ impl<R: Relation> Scope<'_, R> {
     /// This function takes a closure to provide entity mut access.
     pub fn add_target_and(
         &mut self,
-        mut func: impl for<'e> FnMut(&mut EntityMut<'e>),
+        mut func: impl for<'e> FnMut(&mut EntityWorldMut<'e>),
     ) -> &mut Self {
         let id = {
             let mut spawned = self.world.spawn(());
@@ -106,7 +104,7 @@ pub trait EntityMutExt<'a> {
     fn scope<R: Relation>(&mut self, func: impl for<'i> FnMut(&mut Scope<'i, R>)) -> &mut Self;
 }
 
-impl<'a> EntityMutExt<'a> for EntityMut<'a> {
+impl<'a> EntityMutExt<'a> for EntityWorldMut<'a> {
     fn scope<R: Relation>(&mut self, mut func: impl for<'i> FnMut(&mut Scope<'i, R>)) -> &mut Self {
         let _ = R::ZST_OR_PANIC;
 


### PR DESCRIPTION
Bevy 0.12 breaks aery because of the new EntityMut stuff.  Didn't actually want to figure out improvements that could be made from that, just wanted to get this fixed asap, 0.6 could be an opportunity to take advantage of changes if possible.