### PR TITLE
Restrict bevy dependency to bevy_ecs etc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,18 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.12"
+bevy_app = "0.12"
+bevy_derive = "0.12"
+bevy_ecs = "0.12"
+bevy_hierarchy = "0.12"
+bevy_log = "0.12"
+bevy_utils = "0.12"
 smallvec = "1.11.0"
 aery_macros = { path = "macros", version = "0.3.0-dev" }
 aquamarine = "0.3.2"
+
+[dev-dependencies]
+bevy = "0.12"
 
 [features]
 default = ["aery"]

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -3,18 +3,16 @@ use crate::{
     relation::{CleanupPolicy, Relation, RelationId, ZstOrPanic},
 };
 
-use bevy::{
-    ecs::{
-        component::Component,
-        entity::Entity,
-        query::{Or, With, Without, WorldQuery},
-        system::{Command, CommandQueue, Resource},
-        world::{EntityWorldMut, World},
-    },
-    hierarchy::{Children, Parent},
-    log::warn,
-    prelude::{Deref, DerefMut},
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    query::{Or, With, Without, WorldQuery},
+    system::{Command, CommandQueue, Resource},
+    world::{EntityWorldMut, World},
 };
+use bevy_hierarchy::{Children, Parent};
+use bevy_log::warn;
 
 use smallvec::SmallVec;
 use std::marker::PhantomData;
@@ -758,7 +756,7 @@ mod tests {
     use super::Targets;
     use super::{Hosts, OnDelete};
     use crate::prelude::*;
-    use bevy::prelude::*;
+    use bevy_ecs::prelude::*;
     use std::array::from_fn;
 
     fn has_edges(world: &World, entity: Entity) -> bool {

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,6 @@
 use crate::{relation::RelationId, Var};
 
-use bevy::ecs::{entity::Entity, event::Event};
+use bevy_ecs::{entity::Entity, event::Event};
 use std::cmp::PartialEq;
 
 /// Operation type of a relation target event.

--- a/src/for_each.rs
+++ b/src/for_each.rs
@@ -3,7 +3,7 @@ use crate::operations::utils::{
 };
 use crate::tuple_traits::*;
 
-use bevy::ecs::{
+use bevy_ecs::{
     entity::Entity,
     query::{ReadOnlyWorldQuery, WorldQuery},
     system::Query,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,10 +155,8 @@
 //! }
 //! ```
 
-use bevy::{
-    app::{App, Plugin},
-    ecs::entity::Entity,
-};
+use bevy_app::{App, Plugin};
+use bevy_ecs::entity::Entity;
 
 ///
 pub mod edges;

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,6 +1,6 @@
 use crate::{relation::ZstOrPanic, tuple_traits::*};
 
-use bevy::ecs::{
+use bevy_ecs::{
     entity::Entity,
     query::{ReadOnlyWorldQuery, WorldQuery},
     system::Query,
@@ -547,7 +547,8 @@ where
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
-    use bevy::{app::AppExit, prelude::*};
+    use bevy_app::{prelude::*, AppExit};
+    use bevy_ecs::prelude::*;
 
     #[derive(Component)]
     struct S;

--- a/src/operations/utils.rs
+++ b/src/operations/utils.rs
@@ -4,7 +4,7 @@ use crate::{
     tuple_traits::*,
 };
 
-use bevy::ecs::{entity::Entity, query::WorldQuery};
+use bevy_ecs::{entity::Entity, query::WorldQuery};
 
 use std::{any::TypeId, marker::PhantomData};
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -3,7 +3,7 @@ use crate::{
     relation::{Relation, ZstOrPanic},
 };
 
-use bevy::ecs::{
+use bevy_ecs::{
     bundle::Bundle,
     entity::Entity,
     system::{Command, Commands, EntityCommands},

--- a/src/tuple_traits.rs
+++ b/src/tuple_traits.rs
@@ -5,14 +5,12 @@ use crate::{
 };
 use core::any::TypeId;
 
-use bevy::{
-    ecs::{
-        entity::Entity,
-        query::{ReadOnlyWorldQuery, WorldQuery},
-        system::Query,
-    },
-    utils::all_tuples,
+use bevy_ecs::{
+    entity::Entity,
+    query::{ReadOnlyWorldQuery, WorldQuery},
+    system::Query,
 };
+use bevy_utils::all_tuples;
 
 mod sealed {
     use super::*;


### PR DESCRIPTION
Restriction of `bevy` dependency to sub crates as discussed in #18

- `bevy_ecs`, `bevy_app` etc have been added as dependencies
- `bevy` references have been replaced with the corresponding sub crate
- `bevy` has been moved from `dependencies` to `dev-dependencies` as its being used by docs
- references in docs have been left alone, maybe we want to keep using `bevy` there for readability?